### PR TITLE
Allow trusted users more tag adding permissions

### DIFF
--- a/app/views/tag.py
+++ b/app/views/tag.py
@@ -650,8 +650,8 @@ def tag_set_update():
             add_tag = Tag.query.filter_by(id=id).first()
             if add_tag is None:
                 return abort(419, f'Tag with ID={id} not found for appending')
-            if add_tag.tag_type == "Community" or add_tag.tag_type == "Competition":
-                return abort(420, f'Tag with ID={id} not a valid type for appending')
+            if (add_tag.tag_type == "Community" or add_tag.tag_type == "Competition") and not is_user_in_groups(user.id, ['Admin', 'TrustedUser']):
+                return abort(420, f'User does not have permission to add tag with ID={id} becasue of its type')
             
             # Check if the tag is already in the tag_set to avoid duplicates
             if add_tag not in tag_set.tags:
@@ -661,6 +661,9 @@ def tag_set_update():
         for id in remove_tag_ids:
             remove_tag = Tag.query.filter_by(id=id).first()
             if remove_tag and remove_tag in tag_set.tags:
+                if (remove_tag.tag_type == "Community" or remove_tag.tag_type == "Competition") and not is_user_in_groups(user.id, ['Admin', 'TrustedUser']):
+                    return abort(420, f'User does not have permission to remove tag with ID={id} becasue of its type')
+                
                 # The tag exists and is part of the tag_set, so remove it
                 tag_set.tags.remove(remove_tag)
             # If the tag does not exist or is not part of the tag_set, do nothing (skip it)


### PR DESCRIPTION
Gives trusted users the ability to add and remove competition and community tags from game modes. Needed to fix the NNL Season 5 game mode and for any future movement of game modes.