### PR TITLE
Add 2.2.0 OngoingGame fields and migration

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -307,6 +307,19 @@ class OngoingGame(db.Model):
     home_roster_6_char = db.Column(db.Integer, db.ForeignKey('character.char_id'), nullable=False)
     home_roster_7_char = db.Column(db.Integer, db.ForeignKey('character.char_id'), nullable=False)
     home_roster_8_char = db.Column(db.Integer, db.ForeignKey('character.char_id'), nullable=False)
+    away_logo = db.Column(db.Integer)
+    home_logo = db.Column(db.Integer)
+    away_char_ids = db.Column(db.JSON)
+    home_char_ids = db.Column(db.JSON)
+    away_superstars = db.Column(db.JSON)
+    home_superstars = db.Column(db.JSON)
+    away_fielding_positions = db.Column(db.JSON)
+    home_fielding_positions = db.Column(db.JSON)
+    away_inning_scores = db.Column(db.JSON)
+    home_inning_scores = db.Column(db.JSON)
+    star_chance = db.Column(db.Boolean)
+    pitcher_stats = db.Column(db.JSON)
+    batter_stats = db.Column(db.JSON)
     current_inning = db.Column(db.Integer)
     current_half_inning = db.Column(db.Integer)
     current_away_score = db.Column(db.Integer)
@@ -319,6 +332,13 @@ class OngoingGame(db.Model):
     current_runner_3b = db.Column(db.Boolean)
     batter_roster_loc = db.Column(db.Integer)
     pitcher_roster_loc = db.Column(db.Integer)
+    innings_selected = db.Column(db.Integer)
+    loaded_from_hud = db.Column(db.Boolean)
+    chemistry_links_on_base = db.Column(db.Integer)
+    batter_hand = db.Column(db.Integer)
+    current_runner_1b_roster = db.Column(db.Integer)
+    current_runner_2b_roster = db.Column(db.Integer)
+    current_runner_3b_roster = db.Column(db.Integer)
 
     away_user = db.relationship('RioUser', foreign_keys = [away_player_id], backref = 'ongoing_away_games')
     home_user = db.relationship('RioUser', foreign_keys = [home_player_id], backref = 'ongoing_home_games')
@@ -331,12 +351,16 @@ class OngoingGame(db.Model):
             "tag_set": self.tag_set_id,
             "away_captain": self.away_captain,
             "home_captain": self.home_captain,
+            "away_logo": self.away_logo,
+            "home_logo": self.home_logo,
             "start_time": self.date_time_start,
             "stadium_id": self.stadium_id,
             "inning": self.current_inning,
             "half_inning": self.current_half_inning,
             "away_score": self.current_away_score,
             "home_score": self.current_home_score,
+            "away_inning_scores": self.away_inning_scores,
+            "home_inning_scores": self.home_inning_scores,
             "away_roster_0_char": self.away_roster_0_char,
             "away_roster_1_char": self.away_roster_1_char,
             "away_roster_2_char": self.away_roster_2_char,
@@ -346,6 +370,9 @@ class OngoingGame(db.Model):
             "away_roster_6_char": self.away_roster_6_char,
             "away_roster_7_char": self.away_roster_7_char,
             "away_roster_8_char": self.away_roster_8_char,
+            "away_char_ids": self.away_char_ids,
+            "away_superstars": self.away_superstars,
+            "away_fielding_positions": self.away_fielding_positions,
             "home_roster_0_char": self.home_roster_0_char,
             "home_roster_1_char": self.home_roster_1_char,
             "home_roster_2_char": self.home_roster_2_char,
@@ -355,14 +382,27 @@ class OngoingGame(db.Model):
             "home_roster_6_char": self.home_roster_6_char,
             "home_roster_7_char": self.home_roster_7_char,
             "home_roster_8_char": self.home_roster_8_char,
+            "home_char_ids": self.home_char_ids,
+            "home_superstars": self.home_superstars,
+            "home_fielding_positions": self.home_fielding_positions,
             "away_stars": self.current_away_stars,
             "home_stars": self.current_home_stars,
             "outs": self.current_outs,
+            "star_chance": self.star_chance,
             "runner_on_first": self.current_runner_1b,
             "runner_on_second": self.current_runner_2b,
             "runner_on_third": self.current_runner_3b,
             "batter": self.batter_roster_loc,
-            "pitcher": self.pitcher_roster_loc
+            "pitcher": self.pitcher_roster_loc,
+            "pitcher_stats": self.pitcher_stats,
+            "batter_stats": self.batter_stats,
+            "innings_selected": self.innings_selected,
+            "loaded_from_hud": self.loaded_from_hud,
+            "chemistry_links_on_base": self.chemistry_links_on_base,
+            "batter_hand": self.batter_hand,
+            "runner_on_first_roster": self.current_runner_1b_roster,
+            "runner_on_second_roster": self.current_runner_2b_roster,
+            "runner_on_third_roster": self.current_runner_3b_roster,
         }
 
 

--- a/app/views/populate_db.py
+++ b/app/views/populate_db.py
@@ -92,9 +92,9 @@ def update_ongoing_game():
                 current_runner_2b_roster = runner_2b,
                 current_runner_3b = runner_3b >= 0,
                 current_runner_3b_roster = runner_3b,
-                batter_roster_loc = request.json['Batter'],
+                batter_roster_loc = request.json['Batter Roster Loc'],
                 batter_hand = request.json['Batter Hand'],
-                pitcher_roster_loc = request.json['Pitcher'],
+                pitcher_roster_loc = request.json['Pitcher Roster Loc'],
                 chemistry_links_on_base = request.json['Chemistry Links on Base'],
                 pitcher_stats = request.json['Pitcher Stats'],
                 batter_stats = request.json['Batter Stats'],
@@ -119,9 +119,9 @@ def update_ongoing_game():
             game.current_runner_2b_roster = runner_2b
             game.current_runner_3b = runner_3b >= 0
             game.current_runner_3b_roster = runner_3b
-            game.batter_roster_loc = request.json['Batter']
+            game.batter_roster_loc = request.json['Batter Roster Loc']
             game.batter_hand = request.json['Batter Hand']
-            game.pitcher_roster_loc = request.json['Pitcher']
+            game.pitcher_roster_loc = request.json['Pitcher Roster Loc']
             game.chemistry_links_on_base = request.json['Chemistry Links on Base']
             game.away_fielding_positions = request.json['Away Fielding Positions']
             game.home_fielding_positions = request.json['Home Fielding Positions']

--- a/app/views/populate_db.py
+++ b/app/views/populate_db.py
@@ -33,6 +33,10 @@ def update_ongoing_game():
             if home_player.verified is False or away_player.verified is False:
                 return abort(422, "Both users must be verified to submit games.")
 
+            runner_1b = request.json['Runner 1B Roster']
+            runner_2b = request.json['Runner 2B Roster']
+            runner_3b = request.json['Runner 3B Roster']
+
             game = OngoingGame(
                 game_id = game_id,
                 away_player_id = away_player.id,
@@ -40,40 +44,60 @@ def update_ongoing_game():
                 tag_set_id = request.json['TagSetID'],
                 away_captain = request.json['Away Captain'],
                 home_captain = request.json['Home Captain'],
+                away_logo = request.json['Away Logo'],
+                home_logo = request.json['Home Logo'],
                 date_time_start = request.json['Date - Start'],
                 stadium_id = request.json['StadiumID'],
-                current_inning = 1,
-                current_half_inning = 0,
-                current_away_score = 0,
-                current_home_score = 0,
+                innings_selected = request.json['Innings Selected'],
+                loaded_from_hud = request.json['Loaded from HUD'],
+                current_inning = request.json['Inning'],
+                current_half_inning = request.json['Half Inning'],
+                current_away_score = request.json['Away Score'],
+                current_home_score = request.json['Home Score'],
+                away_inning_scores = request.json['Away Inning Scores'],
+                home_inning_scores = request.json['Home Inning Scores'],
 
-                away_roster_0_char = request.json["Away Roster 0 CharID"],
-                away_roster_1_char = request.json["Away Roster 1 CharID"],
-                away_roster_2_char = request.json["Away Roster 2 CharID"],
-                away_roster_3_char = request.json["Away Roster 3 CharID"],
-                away_roster_4_char = request.json["Away Roster 4 CharID"],
-                away_roster_5_char = request.json["Away Roster 5 CharID"],
-                away_roster_6_char = request.json["Away Roster 6 CharID"],
-                away_roster_7_char = request.json["Away Roster 7 CharID"],
-                away_roster_8_char = request.json["Away Roster 8 CharID"],
-                home_roster_0_char = request.json["Home Roster 0 CharID"],
-                home_roster_1_char = request.json["Home Roster 1 CharID"],
-                home_roster_2_char = request.json["Home Roster 2 CharID"],
-                home_roster_3_char = request.json["Home Roster 3 CharID"],
-                home_roster_4_char = request.json["Home Roster 4 CharID"],
-                home_roster_5_char = request.json["Home Roster 5 CharID"],
-                home_roster_6_char = request.json["Home Roster 6 CharID"],
-                home_roster_7_char = request.json["Home Roster 7 CharID"],
-                home_roster_8_char = request.json["Home Roster 8 CharID"],
+                away_roster_0_char = request.json["Away CharIDs"][0],
+                away_roster_1_char = request.json["Away CharIDs"][1],
+                away_roster_2_char = request.json["Away CharIDs"][2],
+                away_roster_3_char = request.json["Away CharIDs"][3],
+                away_roster_4_char = request.json["Away CharIDs"][4],
+                away_roster_5_char = request.json["Away CharIDs"][5],
+                away_roster_6_char = request.json["Away CharIDs"][6],
+                away_roster_7_char = request.json["Away CharIDs"][7],
+                away_roster_8_char = request.json["Away CharIDs"][8],
+                away_char_ids = request.json["Away CharIDs"],
+                away_superstars = request.json["Away Superstars"],
+                away_fielding_positions = request.json["Away Fielding Positions"],
+                home_roster_0_char = request.json["Home CharIDs"][0],
+                home_roster_1_char = request.json["Home CharIDs"][1],
+                home_roster_2_char = request.json["Home CharIDs"][2],
+                home_roster_3_char = request.json["Home CharIDs"][3],
+                home_roster_4_char = request.json["Home CharIDs"][4],
+                home_roster_5_char = request.json["Home CharIDs"][5],
+                home_roster_6_char = request.json["Home CharIDs"][6],
+                home_roster_7_char = request.json["Home CharIDs"][7],
+                home_roster_8_char = request.json["Home CharIDs"][8],
+                home_char_ids = request.json["Home CharIDs"],
+                home_superstars = request.json["Home Superstars"],
+                home_fielding_positions = request.json["Home Fielding Positions"],
 
                 current_away_stars = request.json['Away Stars'],
                 current_home_stars = request.json['Home Stars'],
-                current_outs = 0,
-                current_runner_1b = False,
-                current_runner_2b = False,
-                current_runner_3b = False,
-                batter_roster_loc = 0,
-                pitcher_roster_loc = request.json['Pitcher']
+                current_outs = request.json['Outs'],
+                star_chance = request.json['Star Chance'],
+                current_runner_1b = runner_1b >= 0,
+                current_runner_1b_roster = runner_1b,
+                current_runner_2b = runner_2b >= 0,
+                current_runner_2b_roster = runner_2b,
+                current_runner_3b = runner_3b >= 0,
+                current_runner_3b_roster = runner_3b,
+                batter_roster_loc = request.json['Batter'],
+                batter_hand = request.json['Batter Hand'],
+                pitcher_roster_loc = request.json['Pitcher'],
+                chemistry_links_on_base = request.json['Chemistry Links on Base'],
+                pitcher_stats = request.json['Pitcher Stats'],
+                batter_stats = request.json['Batter Stats'],
             )
         else:
             game.current_inning = request.json['Inning']
@@ -83,11 +107,26 @@ def update_ongoing_game():
             game.current_away_stars = request.json['Away Stars']
             game.current_home_stars = request.json['Home Stars']
             game.current_outs = request.json['Outs']
-            game.current_runner_1b = request.json['Runner 1B']
-            game.current_runner_2b = request.json['Runner 2B']
-            game.current_runner_3b = request.json['Runner 3B']
+            game.away_inning_scores = request.json['Away Inning Scores']
+            game.home_inning_scores = request.json['Home Inning Scores']
+            game.star_chance = request.json['Star Chance']
+            runner_1b = request.json['Runner 1B Roster']
+            runner_2b = request.json['Runner 2B Roster']
+            runner_3b = request.json['Runner 3B Roster']
+            game.current_runner_1b = runner_1b >= 0
+            game.current_runner_1b_roster = runner_1b
+            game.current_runner_2b = runner_2b >= 0
+            game.current_runner_2b_roster = runner_2b
+            game.current_runner_3b = runner_3b >= 0
+            game.current_runner_3b_roster = runner_3b
             game.batter_roster_loc = request.json['Batter']
+            game.batter_hand = request.json['Batter Hand']
             game.pitcher_roster_loc = request.json['Pitcher']
+            game.chemistry_links_on_base = request.json['Chemistry Links on Base']
+            game.away_fielding_positions = request.json['Away Fielding Positions']
+            game.home_fielding_positions = request.json['Home Fielding Positions']
+            game.pitcher_stats = request.json['Pitcher Stats']
+            game.batter_stats = request.json['Batter Stats']
         
         db.session.add(game)
         db.session.commit()

--- a/migrations/versions/b2f4c8a1d3e7_add_2_2_0_ongoing_game_fields.py
+++ b/migrations/versions/b2f4c8a1d3e7_add_2_2_0_ongoing_game_fields.py
@@ -1,0 +1,70 @@
+"""Add 2.2.0 ongoing game fields to ongoing_game table
+
+Adds the new OngoingGame columns introduced for Project Rio 2.2.0's expanded
+ongoing-game submissions (team logos, per-roster char/superstar/fielding-position
+arrays, per-inning score arrays, star chance, live pitcher/batter stat snapshots,
+runner roster locations, etc.). All columns are nullable -- OngoingGame is
+ephemeral (rows are destroyed after ~2 hours) so there is no backfill concern.
+
+Revision ID: b2f4c8a1d3e7
+Revises: f354f1a77f46
+Create Date: 2026-05-31
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'b2f4c8a1d3e7'
+down_revision = 'f354f1a77f46'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('ongoing_game', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('away_logo', sa.Integer(), nullable=True))
+        batch_op.add_column(sa.Column('home_logo', sa.Integer(), nullable=True))
+        batch_op.add_column(sa.Column('away_char_ids', sa.JSON(), nullable=True))
+        batch_op.add_column(sa.Column('home_char_ids', sa.JSON(), nullable=True))
+        batch_op.add_column(sa.Column('away_superstars', sa.JSON(), nullable=True))
+        batch_op.add_column(sa.Column('home_superstars', sa.JSON(), nullable=True))
+        batch_op.add_column(sa.Column('away_fielding_positions', sa.JSON(), nullable=True))
+        batch_op.add_column(sa.Column('home_fielding_positions', sa.JSON(), nullable=True))
+        batch_op.add_column(sa.Column('away_inning_scores', sa.JSON(), nullable=True))
+        batch_op.add_column(sa.Column('home_inning_scores', sa.JSON(), nullable=True))
+        batch_op.add_column(sa.Column('star_chance', sa.Boolean(), nullable=True))
+        batch_op.add_column(sa.Column('pitcher_stats', sa.JSON(), nullable=True))
+        batch_op.add_column(sa.Column('batter_stats', sa.JSON(), nullable=True))
+        batch_op.add_column(sa.Column('innings_selected', sa.Integer(), nullable=True))
+        batch_op.add_column(sa.Column('loaded_from_hud', sa.Boolean(), nullable=True))
+        batch_op.add_column(sa.Column('chemistry_links_on_base', sa.Integer(), nullable=True))
+        batch_op.add_column(sa.Column('batter_hand', sa.Integer(), nullable=True))
+        batch_op.add_column(sa.Column('current_runner_1b_roster', sa.Integer(), nullable=True))
+        batch_op.add_column(sa.Column('current_runner_2b_roster', sa.Integer(), nullable=True))
+        batch_op.add_column(sa.Column('current_runner_3b_roster', sa.Integer(), nullable=True))
+
+
+def downgrade():
+    with op.batch_alter_table('ongoing_game', schema=None) as batch_op:
+        batch_op.drop_column('current_runner_3b_roster')
+        batch_op.drop_column('current_runner_2b_roster')
+        batch_op.drop_column('current_runner_1b_roster')
+        batch_op.drop_column('batter_hand')
+        batch_op.drop_column('chemistry_links_on_base')
+        batch_op.drop_column('loaded_from_hud')
+        batch_op.drop_column('innings_selected')
+        batch_op.drop_column('batter_stats')
+        batch_op.drop_column('pitcher_stats')
+        batch_op.drop_column('star_chance')
+        batch_op.drop_column('home_inning_scores')
+        batch_op.drop_column('away_inning_scores')
+        batch_op.drop_column('home_fielding_positions')
+        batch_op.drop_column('away_fielding_positions')
+        batch_op.drop_column('home_superstars')
+        batch_op.drop_column('away_superstars')
+        batch_op.drop_column('home_char_ids')
+        batch_op.drop_column('away_char_ids')
+        batch_op.drop_column('home_logo')
+        batch_op.drop_column('away_logo')


### PR DESCRIPTION
## Summary
- Ports PR #135 model/populate_db changes onto develop and extends them for 2.2.0
- Adds 20 nullable columns to `OngoingGame`: logos, char/superstar/fielding arrays, inning scores, star chance, pitcher/batter stats, runner roster locs, innings selected, loaded_from_hud, chemistry links, batter hand
- Migration `b2f4c8a1d3e7` (down_revision `f354f1a77f46`) — purely additive, no backfill needed
- CREATE path now reads full game state from the POST payload instead of hardcoding defaults, so HUD-resumed games (new game_id) are initialized correctly
- UPDATE path switches `Runner 1B/2B/3B` boolean keys to `Runner 1B/2B/3B Roster` integer keys with -1 sentinel
- `Batter`/`Pitcher` JSON keys renamed to `Batter Roster Loc`/`Pitcher Roster Loc` for consistency with stat tracker format

## Dependencies
- Requires emulator PR [ProjectRio/ProjectRio#129](https://github.com/ProjectRio/ProjectRio/pull/129) which updates `postOngoingGame()` and `updateOngoingGame()` to send the new payload

## Test plan
- [x] `flask db upgrade` against Test Server — verify no errors and 20 columns added
- [x] `flask db downgrade` — verify clean removal of all 20 columns
- [x] POST to `/populate_db/ongoing_game/` with 2.2.0 emulator payload — verify CREATE populates all fields correctly
- [x] Subsequent POSTs — verify UPDATE path sets runner/batter/pitcher/stats correctly
- [x] HUD resume (new game_id) — verify game created with correct inning/score/state, not defaulting to inning 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)