### PR TITLE
Push game_id filter onto event scan in detailed batting/pitching stats

### DIFF
--- a/app/views/stat_retrieval.py
+++ b/app/views/stat_retrieval.py
@@ -857,7 +857,10 @@ def query_detailed_batting_stats(stat_dict, game_ids, user_ids, char_ids, active
         .join(PitchSummary, PitchSummary.id == Event.pitch_summary_id)
         .outerjoin(ContactSummary, contact_join_condition)
         .join(RioUser, CharacterGameSummary.user_id == RioUser.id)
-        .where(*filters)
+        # Redundant predicate (an event's game always matches its batter's game).
+        # It lets Postgres restrict the event scan via idx_event_game_id instead of
+        # seq-scanning the whole event table before applying the game filter.
+        .where(*filters, Event.game_id.in_(game_ids))
     )
 
     if group_cols:
@@ -957,7 +960,10 @@ def query_detailed_pitching_stats(stat_dict, game_ids, user_ids, char_ids, activ
         .join(Event, CharacterGameSummary.id == Event.pitcher_id)
         .join(PitchSummary, PitchSummary.id == Event.pitch_summary_id)
         .join(RioUser, CharacterGameSummary.user_id == RioUser.id)
-        .where(*filters)
+        # Redundant predicate (an event's game always matches its pitcher's game).
+        # It lets Postgres restrict the event scan via idx_event_game_id instead of
+        # seq-scanning the whole event table before applying the game filter.
+        .where(*filters, Event.game_id.in_(game_ids))
     )
 
     if group_cols:


### PR DESCRIPTION
## Problem

For tag-scoped `/stats/` requests (e.g. an entire season), the detailed **batting** and **pitching** queries were catastrophically slow on production — **60–176s at 100% DB CPU** for a single tag — while single-game requests stayed fast.

Root cause was the query plan, not the hardware or indexes. The contact-batting and pitch-breakdown queries join `event` by `batter_id`/`pitcher_id` but only restricted `character_game_summary.game_id`. With no game restriction on `event` itself, Postgres seq-scanned the full `event` (6M), `pitch_summary` (6M), and `contact_summary` (2.8M) tables, built a ~6M-row join, and applied the tag filter **last** — discarding 99.98% of the work.

Production `EXPLAIN` confirmed: full-table `Seq Scan` cascade, game filter as a top-level `Hash Semi Join`.

## Fix

Add a redundant `Event.game_id.in_(game_ids)` predicate to both event-joined queries. An event's `game_id` always equals its batter's/pitcher's `game_id`, so **results are unchanged** — but it gives the planner an indexable restriction directly on `event`, so it uses `idx_event_game_id` to touch only the relevant events and cascades PK lookups into `pitch_summary`/`contact_summary`.

## Result (production EXPLAIN, ~881-game tag)

| | Plan | Time |
|---|---|---|
| Before | Full-table hash-join cascade, filter applied last | 60–176s |
| After | Index nested loops driven by `idx_event_game_id` | 0.86s warm / 17s cold |

The plan flips from `Seq Scan on event` to `Index Scan using ix_event_batter_id`, with `pitch_summary`/`contact_summary` reached via PK lookups.

## Scope / notes

- Touches only `query_detailed_batting_stats` and `query_detailed_pitching_stats` in `app/views/stat_retrieval.py` (2 lines + comments). No behavior change, no API change.
- Fielding's `FieldingSummary` join has the same shape but no `game_id` column, so it can't take this predicate without a schema change — left as-is.
- Remaining warm-cache cost (~0.86s) is dominated by the `event → pitch_summary → contact_summary` hops; the durable follow-up is merging the 1:1 `PitchSummary` into `Event` (tracked separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)