### PR TITLE
Release: limit_games fix + stat/event query optimizations

### DIFF
--- a/app/tests/test_endpoint_events.py
+++ b/app/tests/test_endpoint_events.py
@@ -143,6 +143,38 @@ class TestGameFilter:
 
 
 # ---------------------------------------------------------------------------
+# limit_games parameter  (regression: dropped on the internal path in v1.6.1)
+# ---------------------------------------------------------------------------
+
+class TestLimitGames:
+    # The events response is keyed by game_id, so the number of outer keys is
+    # exactly the number of resolved games. Before the fix, limit_games was
+    # ignored here and the full tag was resolved.
+    def test_limit_games_1_returns_at_most_one_game(self, server, base_url):
+        r = server.get(f'{base_url}/events/', params={'tag': S13_TAG, 'limit_games': '1'})
+        assert r.status_code == 200
+        assert len(r.json()) <= 1
+
+    def test_more_games_returns_at_least_as_many_games(self, server, base_url):
+        # A generous limit_events keeps the event cap from truncating games.
+        r1 = server.get(f'{base_url}/events/', params={
+            'tag': S13_TAG, 'limit_games': '1', 'limit_events': '5000',
+        })
+        r3 = server.get(f'{base_url}/events/', params={
+            'tag': S13_TAG, 'limit_games': '3', 'limit_events': '5000',
+        })
+        assert r1.status_code == 200
+        assert r3.status_code == 200
+        assert len(r1.json()) <= 1
+        assert len(r3.json()) <= 3
+        assert len(r3.json()) >= len(r1.json())
+
+    def test_invalid_limit_games_returns_400(self, server, base_url):
+        r = server.get(f'{base_url}/events/', params={'tag': S13_TAG, 'limit_games': 'notanumber'})
+        assert r.status_code == 400
+
+
+# ---------------------------------------------------------------------------
 # Tag filter (uses game-level filtering)
 # ---------------------------------------------------------------------------
 

--- a/app/tests/test_endpoint_landing_data.py
+++ b/app/tests/test_endpoint_landing_data.py
@@ -1,0 +1,151 @@
+"""
+Tests for GET /landing_data/
+
+Run against local server (default) or override with BASE_URL env var:
+    BASE_URL=http://hangar51.tailcedf4f.ts.net:5000 pytest app/tests/test_endpoint_landing_data.py
+
+Response format: {'Data': [ {event row dict}, ... ]} where each row carries a
+`game_id`. The endpoint resolves the /games/ filters (tags/users/limit_games/…)
+to a set of games, expands those to events, then returns per-event detail.
+
+Regression anchor: in v1.6.1 `limit_games` was silently dropped on the
+internal game-resolution path, so a tag-scoped request resolved every game in
+the tag and ran an unbounded join until it hit statement_timeout (surfaced as a
+misleading 408 "Invalid GameID"). TestLimitGames locks in that limit_games is
+honored again; TestErrorCodes locks in the corrected 400/404 codes.
+
+Tests are anchored to S13SuperstarsOff — a completed season with stable data.
+"""
+
+import pytest
+
+S13_TAG = 'S13SuperstarsOff'
+
+
+# ---------------------------------------------------------------------------
+# Module-scoped fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope='module')
+def sample_landing_data(server, base_url):
+    """landing_data for a single S13 game (limit_games=1). Skips if empty."""
+    r = server.get(f'{base_url}/landing_data/', params={'tag': S13_TAG, 'limit_games': '1'})
+    if r.status_code != 200:
+        pytest.skip(f'Could not fetch /landing_data/ (status {r.status_code})')
+    data = r.json().get('Data', [])
+    if not data:
+        pytest.skip('No landing_data rows for the S13 sample game')
+    return data
+
+
+@pytest.fixture(scope='module')
+def sample_event_id(server, base_url, sample_game):
+    """A real event id, pulled from /events/ for the shared S13 sample game."""
+    r = server.get(f'{base_url}/events/', params={'games': sample_game['game_id']})
+    if r.status_code != 200:
+        pytest.skip(f'Could not fetch events (status {r.status_code})')
+    events = r.json()
+    for event_map in events.values():
+        for event_id in event_map.values():
+            return event_id
+    pytest.skip('No events found for the S13 sample game')
+
+
+def _distinct_game_ids(data):
+    return {row['game_id'] for row in data}
+
+
+# ---------------------------------------------------------------------------
+# Response shape
+# ---------------------------------------------------------------------------
+
+class TestResponseShape:
+    def test_returns_data_key(self, server, base_url):
+        r = server.get(f'{base_url}/landing_data/', params={'tag': S13_TAG, 'limit_games': '1'})
+        assert r.status_code == 200
+        assert 'Data' in r.json()
+
+    def test_data_is_a_list(self, server, base_url, sample_landing_data):
+        assert isinstance(sample_landing_data, list)
+
+    def test_rows_are_dicts_with_game_id(self, server, base_url, sample_landing_data):
+        for row in sample_landing_data:
+            assert isinstance(row, dict)
+            assert 'game_id' in row
+
+    def test_rows_carry_expected_fields(self, server, base_url, sample_landing_data):
+        expected = {'game_id', 'event_num', 'batter_char_id', 'pitcher_char_id'}
+        for row in sample_landing_data:
+            assert expected <= set(row.keys()), f'Missing {expected - set(row.keys())}'
+
+    def test_empty_filters_with_no_matching_events_returns_empty(self, server, base_url, sample_game):
+        # inning=49 is valid (cMAX_INNING=50) but virtually never occurs → empty result
+        r = server.get(f'{base_url}/landing_data/', params={
+            'games': sample_game['game_id'], 'inning': '49',
+        })
+        assert r.status_code == 200
+        assert r.json() == {}
+
+
+# ---------------------------------------------------------------------------
+# limit_games parameter  (regression: dropped in v1.6.1)
+# ---------------------------------------------------------------------------
+
+class TestLimitGames:
+    def test_limit_games_1_resolves_at_most_one_game(self, server, base_url):
+        # The core regression: before the fix this ignored limit_games, resolved
+        # the entire tag, and timed out (non-200) instead of returning one game.
+        r = server.get(f'{base_url}/landing_data/', params={'tag': S13_TAG, 'limit_games': '1'})
+        assert r.status_code == 200
+        assert len(_distinct_game_ids(r.json()['Data'])) <= 1
+
+    def test_more_games_yields_at_least_as_many_games(self, server, base_url):
+        r1 = server.get(f'{base_url}/landing_data/', params={'tag': S13_TAG, 'limit_games': '1'})
+        r3 = server.get(f'{base_url}/landing_data/', params={'tag': S13_TAG, 'limit_games': '3'})
+        assert r1.status_code == 200
+        assert r3.status_code == 200
+        g1 = _distinct_game_ids(r1.json()['Data'])
+        g3 = _distinct_game_ids(r3.json()['Data'])
+        assert len(g1) <= 1
+        assert len(g3) <= 3
+        assert len(g3) >= len(g1)
+
+
+# ---------------------------------------------------------------------------
+# Explicit events filter
+# ---------------------------------------------------------------------------
+
+class TestEventsFilter:
+    def test_single_event_id_returns_only_that_event(self, server, base_url, sample_event_id):
+        r = server.get(f'{base_url}/landing_data/', params={'events': sample_event_id})
+        assert r.status_code == 200
+        data = r.json().get('Data', [])
+        # An event maps to at most one landing_data row (LEFT JOIN on fielder),
+        # but some events (e.g. strikeouts) have no contact row and drop out.
+        assert len(data) <= 1
+
+
+# ---------------------------------------------------------------------------
+# Error codes  (regression: these all used to return a misleading 408)
+# ---------------------------------------------------------------------------
+
+class TestErrorCodes:
+    def test_invalid_event_id_returns_400(self, server, base_url):
+        r = server.get(f'{base_url}/landing_data/', params={'events': 'notanint'})
+        assert r.status_code == 400
+
+    def test_nonexistent_event_id_returns_404(self, server, base_url):
+        r = server.get(f'{base_url}/landing_data/', params={'events': '999999999999'})
+        assert r.status_code == 404
+
+    def test_unknown_tag_returns_400(self, server, base_url):
+        r = server.get(f'{base_url}/landing_data/', params={'tag': '__no_such_tag_xyzzy__'})
+        assert r.status_code == 400
+
+    def test_unknown_username_returns_400(self, server, base_url):
+        r = server.get(f'{base_url}/landing_data/', params={'username': '__no_such_user_xyzzy__'})
+        assert r.status_code == 400
+
+    def test_invalid_limit_games_returns_400(self, server, base_url):
+        r = server.get(f'{base_url}/landing_data/', params={'tag': S13_TAG, 'limit_games': 'notanumber'})
+        assert r.status_code == 400

--- a/app/tests/test_endpoint_landing_data.py
+++ b/app/tests/test_endpoint_landing_data.py
@@ -110,6 +110,14 @@ class TestLimitGames:
         assert len(g3) <= 3
         assert len(g3) >= len(g1)
 
+    def test_default_no_limit_games_caps_at_50(self, server, base_url):
+        # The original timeout came from resolving an entire tag with no limit.
+        # With no limit_games, the request now resolves at most the newest 50
+        # games (the shared get_game_ids default), so it stays bounded.
+        r = server.get(f'{base_url}/landing_data/', params={'tag': S13_TAG})
+        assert r.status_code == 200
+        assert len(_distinct_game_ids(r.json()['Data'])) <= 50
+
 
 # ---------------------------------------------------------------------------
 # Explicit events filter

--- a/app/tests/test_endpoint_star_chances.py
+++ b/app/tests/test_endpoint_star_chances.py
@@ -1,0 +1,92 @@
+"""
+Tests for GET /star_chances/
+
+Run against local server (default) or override with BASE_URL env var:
+    BASE_URL=http://hangar51.tailcedf4f.ts.net:5000 pytest app/tests/test_endpoint_star_chances.py
+
+Response format: {'Data': [ {..., 'games': N}, ... ]}. By default a single
+aggregate row; with by_inning=true, one row per (inning, half_inning). The
+`games` column is COUNT(DISTINCT event.game_id) over the resolved events.
+
+/star_chances/ resolves games through the same get_game_ids path as
+/landing_data/, so it shares the v1.6.1 limit_games regression and the same
+408 error-code masking. These tests lock in both fixes.
+
+Tests are anchored to S13SuperstarsOff — a completed season with stable data.
+"""
+
+import pytest
+
+S13_TAG = 'S13SuperstarsOff'
+
+
+# ---------------------------------------------------------------------------
+# Response shape
+# ---------------------------------------------------------------------------
+
+class TestResponseShape:
+    def test_returns_data_key(self, server, base_url):
+        r = server.get(f'{base_url}/star_chances/', params={'tag': S13_TAG, 'limit_games': '1'})
+        assert r.status_code == 200
+        assert 'Data' in r.json()
+
+    def test_rows_have_games_count(self, server, base_url):
+        r = server.get(f'{base_url}/star_chances/', params={'tag': S13_TAG, 'limit_games': '1'})
+        assert r.status_code == 200
+        for row in r.json().get('Data', []):
+            assert 'games' in row
+
+    def test_by_inning_adds_inning_keys(self, server, base_url):
+        r = server.get(f'{base_url}/star_chances/', params={
+            'tag': S13_TAG, 'limit_games': '1', 'by_inning': 'true',
+        })
+        assert r.status_code == 200
+        for row in r.json().get('Data', []):
+            assert 'inning' in row
+            assert 'half_inning' in row
+
+
+# ---------------------------------------------------------------------------
+# limit_games parameter  (regression: dropped in v1.6.1)
+# ---------------------------------------------------------------------------
+
+class TestLimitGames:
+    def test_limit_games_1_counts_at_most_one_game(self, server, base_url):
+        # Before the fix this ignored limit_games and aggregated the whole tag.
+        r = server.get(f'{base_url}/star_chances/', params={'tag': S13_TAG, 'limit_games': '1'})
+        assert r.status_code == 200
+        for row in r.json().get('Data', []):
+            assert row['games'] <= 1
+
+    def test_more_games_counts_at_least_as_many(self, server, base_url):
+        r1 = server.get(f'{base_url}/star_chances/', params={'tag': S13_TAG, 'limit_games': '1'})
+        r3 = server.get(f'{base_url}/star_chances/', params={'tag': S13_TAG, 'limit_games': '3'})
+        assert r1.status_code == 200
+        assert r3.status_code == 200
+        games1 = max((row['games'] for row in r1.json().get('Data', [])), default=0)
+        games3 = max((row['games'] for row in r3.json().get('Data', [])), default=0)
+        assert games1 <= 1
+        assert games3 <= 3
+        assert games3 >= games1
+
+
+# ---------------------------------------------------------------------------
+# Error codes  (regression: these all used to return a misleading 408)
+# ---------------------------------------------------------------------------
+
+class TestErrorCodes:
+    def test_invalid_event_id_returns_400(self, server, base_url):
+        r = server.get(f'{base_url}/star_chances/', params={'events': 'notanint'})
+        assert r.status_code == 400
+
+    def test_nonexistent_event_id_returns_404(self, server, base_url):
+        r = server.get(f'{base_url}/star_chances/', params={'events': '999999999999'})
+        assert r.status_code == 404
+
+    def test_unknown_tag_returns_400(self, server, base_url):
+        r = server.get(f'{base_url}/star_chances/', params={'tag': '__no_such_tag_xyzzy__'})
+        assert r.status_code == 400
+
+    def test_invalid_limit_games_returns_400(self, server, base_url):
+        r = server.get(f'{base_url}/star_chances/', params={'tag': S13_TAG, 'limit_games': 'notanumber'})
+        assert r.status_code == 400

--- a/app/tests/test_endpoint_stats.py
+++ b/app/tests/test_endpoint_stats.py
@@ -255,24 +255,6 @@ class TestGroupingByGame:
         assert r.status_code == 200
         assert len(r.json()['Stats']) == 1
 
-    def test_default_no_limit_games_caps_at_50(self, server, base_url):
-        # With no limit_games, /stats/ resolves at most the newest 50 games
-        # (the shared get_game_ids default) instead of the entire tag.
-        r = server.get(f'{base_url}/stats/', params={'tag': S13_TAG, 'by_game': '1'})
-        assert r.status_code == 200
-        assert len(r.json()['Stats']) <= 50
-
-    def test_false_limit_games_exceeds_default(self, server, base_url):
-        # limit_games=False opts out of the 50 default and returns the whole tag,
-        # so it resolves at least as many games as the default-capped request.
-        r_default = server.get(f'{base_url}/stats/', params={'tag': S13_TAG, 'by_game': '1'})
-        r_all = server.get(f'{base_url}/stats/', params={
-            'tag': S13_TAG, 'by_game': '1', 'limit_games': 'False',
-        })
-        assert r_default.status_code == 200
-        assert r_all.status_code == 200
-        assert len(r_all.json()['Stats']) >= len(r_default.json()['Stats'])
-
 
 class TestGroupingByRosterOrder:
     def test_by_roster_order_nests_correctly(self, server, base_url):

--- a/app/tests/test_endpoint_stats.py
+++ b/app/tests/test_endpoint_stats.py
@@ -255,6 +255,24 @@ class TestGroupingByGame:
         assert r.status_code == 200
         assert len(r.json()['Stats']) == 1
 
+    def test_default_no_limit_games_caps_at_50(self, server, base_url):
+        # With no limit_games, /stats/ resolves at most the newest 50 games
+        # (the shared get_game_ids default) instead of the entire tag.
+        r = server.get(f'{base_url}/stats/', params={'tag': S13_TAG, 'by_game': '1'})
+        assert r.status_code == 200
+        assert len(r.json()['Stats']) <= 50
+
+    def test_false_limit_games_exceeds_default(self, server, base_url):
+        # limit_games=False opts out of the 50 default and returns the whole tag,
+        # so it resolves at least as many games as the default-capped request.
+        r_default = server.get(f'{base_url}/stats/', params={'tag': S13_TAG, 'by_game': '1'})
+        r_all = server.get(f'{base_url}/stats/', params={
+            'tag': S13_TAG, 'by_game': '1', 'limit_games': 'False',
+        })
+        assert r_default.status_code == 200
+        assert r_all.status_code == 200
+        assert len(r_all.json()['Stats']) >= len(r_default.json()['Stats'])
+
 
 class TestGroupingByRosterOrder:
     def test_by_roster_order_nests_correctly(self, server, base_url):

--- a/app/tests/test_endpoint_stats.py
+++ b/app/tests/test_endpoint_stats.py
@@ -240,8 +240,18 @@ class TestGroupingByGame:
         assert STAT_CATEGORIES <= set(stats[str(sample_game_id)].keys())
 
     def test_by_game_single_explicit_game_returns_1_game(self, server, base_url, sample_game_id):
-        # /stats/ ignores limit_games; use explicit games= to get a single game
+        # Explicit games= pins the result to exactly one game.
         r = server.get(f'{base_url}/stats/', params={'games': sample_game_id, 'by_game': '1'})
+        assert r.status_code == 200
+        assert len(r.json()['Stats']) == 1
+
+    def test_limit_games_1_resolves_a_single_game(self, server, base_url):
+        # Regression: limit_games was dropped on the /stats/ game-resolution path
+        # in v1.6.1. by_game nests one entry per resolved game, so limit_games=1
+        # must collapse the result to a single game.
+        r = server.get(f'{base_url}/stats/', params={
+            'tag': S13_TAG, 'limit_games': '1', 'by_game': '1',
+        })
         assert r.status_code == 200
         assert len(r.json()['Stats']) == 1
 

--- a/app/views/games.py
+++ b/app/views/games.py
@@ -193,7 +193,7 @@ def parse_limit_games(args, default=None):
         abort(400, f'Invalid limit_games: {raw}')
 
 
-def get_game_ids(args, default_limit=None):
+def get_game_ids(args, default_limit=50):
     """Resolve filter args to an ordered list of game_ids.
 
     ``limit_games`` is parsed here (via parse_limit_games) so that every caller
@@ -204,8 +204,11 @@ def get_game_ids(args, default_limit=None):
 
     Args:
         args: request.args (or any MultiDict with the same interface)
-        default_limit: cap applied when ``limit_games`` is absent. None means no
-            cap. /games/ passes 50; internal callers leave it at None.
+        default_limit: cap applied when ``limit_games`` is absent. Defaults to 50
+            (the newest 50 games) so no endpoint resolves an entire tag by
+            accident. Pass None for no default cap. An explicit limit_games is
+            always honored with no ceiling — limit_games=False returns every
+            matching game and limit_games=N returns N.
 
     Returns:
         Ordered list of game_ids matching the filters (newest first).
@@ -370,8 +373,8 @@ def get_game_ids(args, default_limit=None):
 '''
 @app.route('/games/', methods=['GET'])
 def endpoint_games():
-    # /games/ caps at 50 games when limit_games is absent; get_game_ids parses it.
-    ordered_game_ids = get_game_ids(request.args, default_limit=50)
+    # get_game_ids parses limit_games and defaults to the newest 50 games.
+    ordered_game_ids = get_game_ids(request.args)
 
     include_linescore = (request.args.get('include_linescore') == '1')
     include_scoring_plays = (request.args.get('include_scoring_plays') == '1')

--- a/app/views/games.py
+++ b/app/views/games.py
@@ -193,7 +193,7 @@ def parse_limit_games(args, default=None):
         abort(400, f'Invalid limit_games: {raw}')
 
 
-def get_game_ids(args, default_limit=50):
+def get_game_ids(args, default_limit=None):
     """Resolve filter args to an ordered list of game_ids.
 
     ``limit_games`` is parsed here (via parse_limit_games) so that every caller
@@ -204,11 +204,13 @@ def get_game_ids(args, default_limit=50):
 
     Args:
         args: request.args (or any MultiDict with the same interface)
-        default_limit: cap applied when ``limit_games`` is absent. Defaults to 50
-            (the newest 50 games) so no endpoint resolves an entire tag by
-            accident. Pass None for no default cap. An explicit limit_games is
-            always honored with no ceiling — limit_games=False returns every
-            matching game and limit_games=N returns N.
+        default_limit: cap applied when ``limit_games`` is absent. None means no
+            cap (resolve every matching game). The endpoints that page through
+            individual games — /games/ and /landing_data/ — pass 50; the
+            aggregate / event-bounded endpoints (/stats/, /star_chances/,
+            /events/) leave it None. An explicit limit_games is always honored
+            with no ceiling: limit_games=False returns every matching game and
+            limit_games=N returns N.
 
     Returns:
         Ordered list of game_ids matching the filters (newest first).
@@ -373,8 +375,9 @@ def get_game_ids(args, default_limit=50):
 '''
 @app.route('/games/', methods=['GET'])
 def endpoint_games():
-    # get_game_ids parses limit_games and defaults to the newest 50 games.
-    ordered_game_ids = get_game_ids(request.args)
+    # /games/ pages through games, so it caps at the newest 50 when limit_games
+    # is absent; get_game_ids parses limit_games itself.
+    ordered_game_ids = get_game_ids(request.args, default_limit=50)
 
     include_linescore = (request.args.get('include_linescore') == '1')
     include_scoring_plays = (request.args.get('include_scoring_plays') == '1')

--- a/app/views/games.py
+++ b/app/views/games.py
@@ -171,17 +171,48 @@ def build_linescore_and_scoring_plays(game_innings, include_linescore, include_s
 
 
 
-def get_game_ids(args, limit=None):
+def parse_limit_games(args, default=None):
+    """Parse the ``limit_games`` query param into a row limit.
+
+    Returns:
+        - ``default`` when ``limit_games`` is absent
+        - ``None`` (no limit) for the falsy sentinels 'False'/'false'/'f'
+        - the integer value otherwise
+
+    Calls abort(400) on a non-integer value.
+    """
+    raw = args.get('limit_games')
+    if raw is None:
+        return default
+    #TODO - support truthy and falsy values more broadly (e.g., true/false, yes/no)
+    if raw in ('False', 'false', 'f'):
+        return None
+    try:
+        return int(raw)
+    except ValueError:
+        abort(400, f'Invalid limit_games: {raw}')
+
+
+def get_game_ids(args, default_limit=None):
     """Resolve filter args to an ordered list of game_ids.
+
+    ``limit_games`` is parsed here (via parse_limit_games) so that every caller
+    — the public /games/ endpoint and the internal event/stat endpoints alike —
+    honors it through one shared code path. (Previously the limit was parsed only
+    in endpoint_games(); internal callers passed a hardcoded limit and silently
+    dropped limit_games, which left /landing_data/ etc. resolving an entire tag.)
 
     Args:
         args: request.args (or any MultiDict with the same interface)
-        limit: max games to return; None means no limit
+        default_limit: cap applied when ``limit_games`` is absent. None means no
+            cap. /games/ passes 50; internal callers leave it at None.
 
     Returns:
         Ordered list of game_ids matching the filters (newest first).
         Calls abort(400) directly on invalid input.
     """
+    limit = parse_limit_games(args, default=default_limit)
+
     # === Resolve names -> ids (each set must fully resolve) ===
     include_tag_ids = resolve_names(
         args.getlist('tag'), Tag.id, Tag.name_lowercase,
@@ -339,20 +370,8 @@ def get_game_ids(args, limit=None):
 '''
 @app.route('/games/', methods=['GET'])
 def endpoint_games():
-    # Parse limit before delegating to get_game_ids
-    limit_games_param = request.args.get('limit_games')
-    if limit_games_param is None:
-        limit = 50
-    #TODO - support truthy and falsy values more broadly (e.g., true/false, yes/no)
-    elif limit_games_param in ('False', 'false', 'f'):
-        limit = None
-    else:
-        try:
-            limit = int(limit_games_param)
-        except ValueError:
-            abort(400, f'Invalid limit_games: {limit_games_param}')
-
-    ordered_game_ids = get_game_ids(request.args, limit=limit)
+    # /games/ caps at 50 games when limit_games is absent; get_game_ids parses it.
+    ordered_game_ids = get_game_ids(request.args, default_limit=50)
 
     include_linescore = (request.args.get('include_linescore') == '1')
     include_scoring_plays = (request.args.get('include_scoring_plays') == '1')

--- a/app/views/stat_retrieval.py
+++ b/app/views/stat_retrieval.py
@@ -201,7 +201,7 @@ def build_where_statement(game_ids, char_ids, user_ids):
     - final_result     [0-16],  value for the final result of the event
     - limit_events            int or False, value to limit the events
 '''
-def _parse_event_args(args):
+def _parse_event_args(args, default_game_limit=None):
     if len(args.getlist('games')) != 0:
         try:
             list_of_game_ids = [int(game_id) for game_id in args.getlist('games')]
@@ -213,8 +213,9 @@ def _parse_event_args(args):
         if len(existing_ids) != len(list_of_game_ids):
             abort(404, description='Provided GameIDs not found')
     else:
-        # get_game_ids defaults to the newest 50 games unless limit_games is set.
-        list_of_game_ids = get_game_ids(args)
+        # default_game_limit is the cap applied when limit_games is absent:
+        # /landing_data/ passes 50; the aggregate/event-bounded callers leave it None.
+        list_of_game_ids = get_game_ids(args, default_limit=default_game_limit)
 
     list_of_batter_user_ids = []
     list_of_pitcher_user_ids = []
@@ -356,17 +357,19 @@ def _build_event_stmt(filters, aliases, columns):
     return stmt
 
 
-def get_event_ids(args, limit=None):
+def get_event_ids(args, limit=None, default_game_limit=None):
     """Return a flat list of event IDs matching the given query args.
 
     Args:
         args: request.args (or any MultiDict with the same interface)
         limit: max events to return; None means no limit
+        default_game_limit: game cap applied when limit_games is absent, forwarded
+            to get_game_ids (None = resolve every matching game).
 
     Returns:
         List of event IDs matching the filters.
     """
-    parsed = _parse_event_args(args)
+    parsed = _parse_event_args(args, default_game_limit=default_game_limit)
     filters, aliases = _build_event_filters(parsed)
     stmt = _build_event_stmt(filters, aliases, [Event.id.label('event_id')])
     if limit is not None:
@@ -468,14 +471,15 @@ def endpoint_event():
 #         'Data': data
 #     }
 
-def _resolve_event_ids(args):
+def _resolve_event_ids(args, default_game_limit=None):
     """Resolve an events-based request to a list of event ids.
 
     If explicit ``events`` ids are supplied they are validated (400 if any is
     non-integer, 404 if any does not exist). Otherwise the game/event filters
-    are resolved via get_event_ids(), which honors limit_games. Aborts with the
-    matching 4xx code on bad input; database errors are left to propagate rather
-    than being masked behind a misleading 408 "Invalid GameID".
+    are resolved via get_event_ids(), which honors limit_games (defaulting to
+    default_game_limit games when it is absent). Aborts with the matching 4xx
+    code on bad input; database errors are left to propagate rather than being
+    masked behind a misleading 408 "Invalid GameID".
     """
     explicit_events = args.getlist('events')
     if explicit_events:
@@ -489,12 +493,14 @@ def _resolve_event_ids(args):
         if set(found) != set(event_ids):
             abort(404, description='Provided Events not found')
         return event_ids
-    return get_event_ids(args)
+    return get_event_ids(args, default_game_limit=default_game_limit)
 
 
 @app.route('/landing_data/', methods = ['GET'])
 def endpoint_landing_data():
-    list_of_event_ids = _resolve_event_ids(request.args)
+    # /landing_data/ pages through games, so it caps at the newest 50 games when
+    # limit_games is absent (keeping the per-event join bounded).
+    list_of_event_ids = _resolve_event_ids(request.args, default_game_limit=50)
 
     event_id_string, event_empty = format_list_for_SQL(list_of_event_ids)
 
@@ -582,6 +588,7 @@ def endpoint_landing_data():
 '''
 @app.route('/star_chances/', methods = ['GET'])
 def endpoint_star_chances():
+    # Aggregate view: resolve every matching game by default (no 50-game cap).
     list_of_event_ids = _resolve_event_ids(request.args)
 
     event_id_string, event_empty = format_list_for_SQL(list_of_event_ids)
@@ -717,7 +724,7 @@ def endpoint_detailed_stats():
         if missing_ids:
             return abort(404, description=f'Game IDs not found: {missing_ids}')
     else:
-        # get_game_ids defaults to the newest 50 games unless limit_games is set.
+        # Aggregate view: resolve every matching game by default (no 50-game cap).
         game_ids = set(get_game_ids(request.args))
         if not game_ids:
             return abort(404, description='No games found for provided parameters')

--- a/app/views/stat_retrieval.py
+++ b/app/views/stat_retrieval.py
@@ -213,7 +213,7 @@ def _parse_event_args(args):
         if len(existing_ids) != len(list_of_game_ids):
             abort(404, description='Provided GameIDs not found')
     else:
-        # default_limit=None: no cap unless the caller passes limit_games.
+        # get_game_ids defaults to the newest 50 games unless limit_games is set.
         list_of_game_ids = get_game_ids(args)
 
     list_of_batter_user_ids = []
@@ -717,7 +717,7 @@ def endpoint_detailed_stats():
         if missing_ids:
             return abort(404, description=f'Game IDs not found: {missing_ids}')
     else:
-        # default_limit=None: no cap unless the caller passes limit_games.
+        # get_game_ids defaults to the newest 50 games unless limit_games is set.
         game_ids = set(get_game_ids(request.args))
         if not game_ids:
             return abort(404, description='No games found for provided parameters')

--- a/app/views/stat_retrieval.py
+++ b/app/views/stat_retrieval.py
@@ -857,7 +857,10 @@ def query_detailed_batting_stats(stat_dict, game_ids, user_ids, char_ids, active
         .join(PitchSummary, PitchSummary.id == Event.pitch_summary_id)
         .outerjoin(ContactSummary, contact_join_condition)
         .join(RioUser, CharacterGameSummary.user_id == RioUser.id)
-        .where(*filters)
+        # Redundant predicate (an event's game always matches its batter's game).
+        # It lets Postgres restrict the event scan via idx_event_game_id instead of
+        # seq-scanning the whole event table before applying the game filter.
+        .where(*filters, Event.game_id.in_(game_ids))
     )
 
     if group_cols:
@@ -957,7 +960,10 @@ def query_detailed_pitching_stats(stat_dict, game_ids, user_ids, char_ids, activ
         .join(Event, CharacterGameSummary.id == Event.pitcher_id)
         .join(PitchSummary, PitchSummary.id == Event.pitch_summary_id)
         .join(RioUser, CharacterGameSummary.user_id == RioUser.id)
-        .where(*filters)
+        # Redundant predicate (an event's game always matches its pitcher's game).
+        # It lets Postgres restrict the event scan via idx_event_game_id instead of
+        # seq-scanning the whole event table before applying the game filter.
+        .where(*filters, Event.game_id.in_(game_ids))
     )
 
     if group_cols:

--- a/app/views/stat_retrieval.py
+++ b/app/views/stat_retrieval.py
@@ -213,7 +213,8 @@ def _parse_event_args(args):
         if len(existing_ids) != len(list_of_game_ids):
             abort(404, description='Provided GameIDs not found')
     else:
-        list_of_game_ids = get_game_ids(args, limit=None)
+        # default_limit=None: no cap unless the caller passes limit_games.
+        list_of_game_ids = get_game_ids(args)
 
     list_of_batter_user_ids = []
     list_of_pitcher_user_ids = []
@@ -467,21 +468,33 @@ def endpoint_event():
 #         'Data': data
 #     }
 
+def _resolve_event_ids(args):
+    """Resolve an events-based request to a list of event ids.
+
+    If explicit ``events`` ids are supplied they are validated (400 if any is
+    non-integer, 404 if any does not exist). Otherwise the game/event filters
+    are resolved via get_event_ids(), which honors limit_games. Aborts with the
+    matching 4xx code on bad input; database errors are left to propagate rather
+    than being masked behind a misleading 408 "Invalid GameID".
+    """
+    explicit_events = args.getlist('events')
+    if explicit_events:
+        try:
+            event_ids = [int(event_id) for event_id in explicit_events]
+        except ValueError:
+            abort(400, description='Invalid event ID (must be an integer)')
+        found = db.session.execute(
+            select(Event.id).where(Event.id.in_(event_ids))
+        ).scalars().all()
+        if set(found) != set(event_ids):
+            abort(404, description='Provided Events not found')
+        return event_ids
+    return get_event_ids(args)
+
+
 @app.route('/landing_data/', methods = ['GET'])
 def endpoint_landing_data():
-    #Sanitize games params 
-    try:
-        list_of_event_ids = list() # Holds IDs for all the events we want data from
-        if (len(request.args.getlist('events')) != 0):
-            list_of_event_ids = [int(game_id) for game_id in request.args.getlist('events')]
-            list_of_event_id_tuples = db.session.query(Event.id).filter(Event.id.in_(tuple(list_of_event_ids))).all()
-            if (len(list_of_event_id_tuples) != len(list_of_event_ids)):
-                return abort(408, description='Provided Events not found')
-
-        else:
-            list_of_event_ids = get_event_ids(request.args)
-    except:
-        return abort(408, description='Invalid GameID')
+    list_of_event_ids = _resolve_event_ids(request.args)
 
     event_id_string, event_empty = format_list_for_SQL(list_of_event_ids)
 
@@ -569,19 +582,7 @@ def endpoint_landing_data():
 '''
 @app.route('/star_chances/', methods = ['GET'])
 def endpoint_star_chances():
-    #Sanitize games params 
-    try:
-        list_of_event_ids = list() # Holds IDs for all the events we want data from
-        if (len(request.args.getlist('events')) != 0):
-            list_of_event_ids = [int(game_id) for game_id in request.args.getlist('events')]
-            list_of_event_id_tuples = db.session.query(Event.id).filter(Event.id.in_(tuple(list_of_event_ids))).all()
-            if (len(list_of_event_id_tuples) != len(list_of_event_ids)):
-                return abort(408, description='Provided Events not found')
-
-        else:
-            list_of_event_ids = get_event_ids(request.args)
-    except:
-        return abort(408, description='Invalid GameID')
+    list_of_event_ids = _resolve_event_ids(request.args)
 
     event_id_string, event_empty = format_list_for_SQL(list_of_event_ids)
 
@@ -716,7 +717,8 @@ def endpoint_detailed_stats():
         if missing_ids:
             return abort(404, description=f'Game IDs not found: {missing_ids}')
     else:
-        game_ids = set(get_game_ids(request.args, limit=None))
+        # default_limit=None: no cap unless the caller passes limit_games.
+        game_ids = set(get_game_ids(request.args))
         if not game_ids:
             return abort(404, description='No games found for provided parameters')
 

--- a/scripts/bench_stats.py
+++ b/scripts/bench_stats.py
@@ -6,6 +6,9 @@ Usage:
     # Run a benchmark and save results
     python scripts/bench_stats.py --base-url http://127.0.0.1:5000 --label main
 
+    # Run with recovery wait: if a scenario fails completely, wait 300s before next scenario
+    python scripts/bench_stats.py --base-url https://api.projectrio.app/ --label web_before --recovery-wait 300
+
     # Compare two saved result files
     python scripts/bench_stats.py --compare scripts/bench_results/20260607_120000_main.json \\
                                             scripts/bench_results/20260607_130000_optimized.json
@@ -67,7 +70,7 @@ def _timed_get(session, url, params):
     return r, (time.perf_counter() - t0) * 1000
 
 
-def run_scenario(session, base_url, name, path, params, warmup, runs):
+def run_scenario(session, base_url, name, path, params, warmup, runs, recovery_wait=None):
     url = base_url.rstrip('/') + path
     print(f"  {name:60s} ", end='', flush=True)
 
@@ -80,7 +83,8 @@ def run_scenario(session, base_url, name, path, params, warmup, runs):
     print(' | ', end='', flush=True)
 
     times, failures = [], 0
-    for _ in range(runs):
+    failed = False
+    for i in range(runs):
         try:
             r, ms = _timed_get(session, url, params)
             if r.status_code == 200:
@@ -89,9 +93,17 @@ def run_scenario(session, base_url, name, path, params, warmup, runs):
             else:
                 failures += 1
                 print('✗', end='', flush=True)
+                failed = True
         except Exception:
             failures += 1
             print('!', end='', flush=True)
+            failed = True
+
+        if failed and recovery_wait:
+            remaining = runs - i - 1
+            if remaining > 0:
+                print(f" (skipping {remaining} remaining)", end='', flush=True)
+            break
     print()
 
     result = {'name': name, 'params': params or {}, 'n_ok': len(times), 'n_fail': failures}
@@ -99,6 +111,15 @@ def run_scenario(session, base_url, name, path, params, warmup, runs):
         result.update(_stats(times))
     else:
         result['error'] = 'all_failed'
+
+    if failed and recovery_wait:
+        print(f"    Waiting {recovery_wait}s for server recovery...", end='', flush=True)
+        for i in range(recovery_wait):
+            time.sleep(1)
+            if (i + 1) % 10 == 0:
+                print(f" {i+1}s", end='', flush=True)
+        print(" done.")
+
     return result
 
 
@@ -107,7 +128,7 @@ def run_scenario(session, base_url, name, path, params, warmup, runs):
 # ---------------------------------------------------------------------------
 
 BENCH_USERNAME = 'MattGree'
-S13 = 'S13SuperstarsOff'
+S13 = 'S13SuperstarsOn'
 BOX_SCORE_GAME_ID = '73655420823'
 
 
@@ -244,6 +265,8 @@ def main():
                         help=f'Timed requests per scenario (default: {DEFAULT_RUNS})')
     parser.add_argument('--include-expensive', action='store_true',
                         help='Add pitcher_wins and runs_scored scenarios (slow on large datasets)')
+    parser.add_argument('--recovery-wait', type=int, default=None,
+                        help='If a scenario fails completely, wait N seconds before next scenario (skips remaining runs of failed scenario)')
     parser.add_argument('--compare', nargs=2, metavar=('FILE_A', 'FILE_B'),
                         help='Compare two saved result files instead of running a benchmark')
     args = parser.parse_args()
@@ -271,7 +294,7 @@ def main():
 
     print("Running:")
     results = [
-        run_scenario(session, args.base_url, name, path, params, args.warmup, args.runs)
+        run_scenario(session, args.base_url, name, path, params, args.warmup, args.runs, args.recovery_wait)
         for name, path, params in scenarios
     ]
 


### PR DESCRIPTION
Promotes the current `develop` to `main`. Three merged PRs since the last release:

- **#152 — Restore `limit_games` on the internal game-resolution path.** Fixes `/landing_data/` (and `/events/`, `/star_chances/`, `/stats/`) silently ignoring `limit_games` since v1.6.1, which made tag-scoped requests resolve the whole tag and time out behind a misleading 408 "Invalid GameID". Also: `/games/` and `/landing_data/` now default to the newest 50 games (aggregate views stay uncapped, no hard ceiling), and the bare `except → 408` in `/landing_data/` and `/star_chances/` is replaced with correct 400/404 codes. Adds regression pytests for all four endpoints.
- **#151 — Push the `game_id` filter onto the event scan in detailed batting/pitching stats.** Query optimization for `/stats/`.
- **#150 — bench_stats.py: add `--recovery-wait` flag and S13SuperstarsOn.** Benchmarking tooling.

### Diff
```
 app/tests/test_endpoint_events.py       |  32 +
 app/tests/test_endpoint_landing_data.py | 159 +
 app/tests/test_endpoint_star_chances.py |  92 +
 app/tests/test_endpoint_stats.py        |  12 +-
 app/views/games.py                      |  57 +-
 app/views/stat_retrieval.py             |  81 +-
 scripts/bench_stats.py                  |  31 +-
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)